### PR TITLE
Fix vitepress not rendering correct title

### DIFF
--- a/index.md
+++ b/index.md
@@ -6,7 +6,7 @@ home: true
 
 Diese Seite enthält verschiedene Materialien für die Inf-Einf-Labs.
 
-> [!IMPORTANT]
+> [!IMPORTANT] Wichtig
 > Der Inhalt dieser Seite wurde nicht offiziell vom Lehrstuhl veröffentlicht. Die offiziellen Inhalte sind auf der Website [inf.zone](https://inf.zone) zu finden.
 >
 > Deshalb sind **ALLE** Inhalte auf dieser Seite auch _nicht direkt relevant_ für die Klausur! Diese Materialien sollen dir jedoch helfen, ein tieferes Verständnis des Kursinhalts zu erlangen und dich auf die Prüfung vorzubereiten.


### PR DESCRIPTION
Currently, there is a bug in vitepress, that does not correctly respect the custom titles for GFM alerts.

Therefore i choose to set a custom title on the index page to not greet users with an english message.