### PR TITLE
Update Labs section by adding links

### DIFF
--- a/index.md
+++ b/index.md
@@ -14,9 +14,8 @@ Diese Seite enthält verschiedene Materialien für die Inf-Einf-Labs.
 ## Labs
 
 -   [Passwort](./password)
-
-<!--
 -   [Kiosk](./snackbar)
+<!--
 -   [Temperatur](./temperature)
 -   [Wasserzeichen](./watermark)
 -   [Fehler](./errors)


### PR DESCRIPTION
Removed 'Kiosk' and 'Temperatur' links from Labs section.